### PR TITLE
SEO: Add branded headers and cross-links to README and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms): The AI-Powered Drupal CMS
+> **Analyze AI Content Security Audit** is a Drupal module by [DXPR](https://dxpr.com) that
+> scans Drupal content for security risks, PII exposure, and compliance issues using AI analysis. Part of the [Analyze](https://www.drupal.org/project/analyze) ecosystem, maintained by [DXPR](https://dxpr.com).
 >
-> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+> [Getting Started](https://dxpr.com/c/getting-started) |
+> [Pricing](https://dxpr.com/pricing) |
+> [Try Free Demo](https://dxpr.com/try)
 
 # AI Content Security Audit: AI-Powered PII and Credential Leak Detection for Drupal
 
@@ -115,8 +118,10 @@ Copilot, Cursor, and other tools supporting the
   live
 - **Audit Trails**: Historical tracking of security risk remediation
 
-## Related DXPR Modules
+## Related Modules
 
 - [Analyze](https://www.drupal.org/project/analyze)
 - [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links)
 - [AI Sentiments Analysis](https://www.drupal.org/project/analyze_ai_sentiments)
+- [AI](https://www.drupal.org/project/ai) - Artificial Intelligence integration for Drupal
+- [ECA](https://www.drupal.org/project/eca) - Event-Condition-Action automation for Drupal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# AI Content Security Audit
+> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms): The AI-Powered Drupal CMS
+>
+> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+
+# AI Content Security Audit: AI-Powered PII and Credential Leak Detection for Drupal
 
 AI-powered content security risk analysis identifying potential PII disclosure,
 credential exposure, and sensitive information leaks before publication.
@@ -110,3 +114,9 @@ Copilot, Cursor, and other tools supporting the
 - **Publication Workflows**: Security risk assessment before content goes
   live
 - **Audit Trails**: Historical tracking of security risk remediation
+
+## Related DXPR Modules
+
+- [Analyze](https://www.drupal.org/project/analyze)
+- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links)
+- [AI Sentiments Analysis](https://www.drupal.org/project/analyze_ai_sentiments)

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ Copilot, Cursor, and other tools supporting the
 
 ## Related Modules
 
-- [Analyze](https://www.drupal.org/project/analyze)
-- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links)
-- [AI Sentiments Analysis](https://www.drupal.org/project/analyze_ai_sentiments)
-- [AI](https://www.drupal.org/project/ai) - Artificial Intelligence integration for Drupal
-- [ECA](https://www.drupal.org/project/eca) - Event-Condition-Action automation for Drupal
+- [Analyze](https://www.drupal.org/project/analyze) - Required. Provides the plugin framework, Analyze tab, and batch processing this module extends
+- [AI](https://www.drupal.org/project/ai) - Required. Supplies the LLM provider used for evaluating content against security vectors
+- [Views Color Scales](https://www.drupal.org/project/views_color_scales) - Required. Renders color-coded risk score columns in the security audit Views report
+- [AI Content Marketing Audit](https://www.drupal.org/project/analyze_ai_content_marketing_audit) - Sibling Analyze plugin that scores marketing effectiveness
+- [AI Sentiments Analysis](https://www.drupal.org/project/analyze_ai_sentiments) - Sibling Analyze plugin that measures tone, trust, and reading level
+- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links) - Sibling Analyze plugin that checks link health without AI

--- a/docs/analyze_ai_content_security_audit_project_desc.html
+++ b/docs/analyze_ai_content_security_audit_project_desc.html
@@ -1,5 +1,3 @@
-<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR</a> ecosystem</strong> - the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
-
 <p>This module is part of the <a href="https://www.drupal.org/project/ai">AI module</a> ecosystem and included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <h2>Sensitive Data Leaks in Content Are Invisible Until They're Not</h2>
@@ -82,9 +80,11 @@
   </ul>
 </p>
 
-<h3>Related DXPR Modules</h3>
+<h3>Related Modules</h3>
 <ul>
 <li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
 <li><a href="https://www.drupal.org/project/analyze_broken_links">Analyze Broken Links</a> - Automated broken link detection and reporting</li>
 <li><a href="https://www.drupal.org/project/analyze_ai_sentiments">AI Sentiments Analysis</a> - Multi-dimensional trust, objectivity, and reading level analysis</li>
+<li><a href="https://www.drupal.org/project/ai">AI</a> - Drupal AI integration framework</li>
+<li><a href="https://www.drupal.org/project/eca">ECA</a> - event-condition-action automation</li>
 </ul>

--- a/docs/analyze_ai_content_security_audit_project_desc.html
+++ b/docs/analyze_ai_content_security_audit_project_desc.html
@@ -82,9 +82,12 @@
 
 <h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
-<li><a href="https://www.drupal.org/project/analyze_broken_links">Analyze Broken Links</a> - Automated broken link detection and reporting</li>
-<li><a href="https://www.drupal.org/project/analyze_ai_sentiments">AI Sentiments Analysis</a> - Multi-dimensional trust, objectivity, and reading level analysis</li>
-<li><a href="https://www.drupal.org/project/ai">AI</a> - Drupal AI integration framework</li>
-<li><a href="https://www.drupal.org/project/eca">ECA</a> - event-condition-action automation</li>
+<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Required. Provides the plugin framework, Analyze tab, and batch processing this module extends</li>
+<li><a href="https://www.drupal.org/project/ai">AI</a> - Required. Supplies the LLM provider used for evaluating content against security vectors</li>
+<li><a href="https://www.drupal.org/project/views_color_scales">Views Color Scales</a> - Required. Renders color-coded risk score columns in the security audit Views report</li>
+<li><a href="https://www.drupal.org/project/analyze_ai_content_marketing_audit">AI Content Marketing Audit</a> - Sibling Analyze plugin that scores marketing effectiveness</li>
+<li><a href="https://www.drupal.org/project/analyze_ai_sentiments">AI Sentiments Analysis</a> - Sibling Analyze plugin that measures tone, trust, and reading level</li>
+<li><a href="https://www.drupal.org/project/analyze_broken_links">Analyze Broken Links</a> - Sibling Analyze plugin that checks link health without AI</li>
 </ul>
+
+<p>AI Content Security Audit is part of the Analyze suite included in <a href="https://dxpr.com/c/marketing-cms">DXPR CMS</a>, a turnkey <a href="https://dxpr.com/c/marketing-cms">marketing CMS</a> for Drupal that combines content analysis, a <a href="https://dxpr.com/c/premium-drupal-theme">premium Drupal theme</a>, and a <a href="https://dxpr.com/c/drupal-layout-builder">drag-and-drop layout builder</a>. See <a href="https://dxpr.com/c/getting-started">getting started</a> or explore <a href="https://dxpr.com/pricing">pricing</a>.</p>

--- a/docs/analyze_ai_content_security_audit_project_desc.html
+++ b/docs/analyze_ai_content_security_audit_project_desc.html
@@ -1,3 +1,5 @@
+<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR</a> ecosystem</strong> - the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
+
 <p>This module is part of the <a href="https://www.drupal.org/project/ai">AI module</a> ecosystem and included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <h2>Sensitive Data Leaks in Content Are Invisible Until They're Not</h2>
@@ -79,3 +81,10 @@
     <li><a href="https://www.drupal.org/project/views_color_scales">Views Color Scales</a> module</li>
   </ul>
 </p>
+
+<h3>Related DXPR Modules</h3>
+<ul>
+<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
+<li><a href="https://www.drupal.org/project/analyze_broken_links">Analyze Broken Links</a> - Automated broken link detection and reporting</li>
+<li><a href="https://www.drupal.org/project/analyze_ai_sentiments">AI Sentiments Analysis</a> - Multi-dimensional trust, objectivity, and reading level analysis</li>
+</ul>


### PR DESCRIPTION
## Summary
- Added branded DXPR CMS header with links to dxpr.com product pages at top of README.md and project description
- Improved H1 title with descriptive keyword-rich suffix for better search visibility
- Added Related DXPR Modules section at bottom of both files for cross-linking to sibling modules

## SEO Impact
- Improved discoverability through keyword-rich H1 title including "Drupal" and core value proposition
- Cross-links to sibling modules (Analyze, Broken Links, AI Sentiments) improve internal linking
- Branded header drives traffic to dxpr.com product pages and documentation