### PR TITLE
Implement getAnalyzedEntityIds() for efficient batch assembly

### DIFF
--- a/src/Plugin/Analyze/AIContentSecurityAuditAnalyzer.php
+++ b/src/Plugin/Analyze/AIContentSecurityAuditAnalyzer.php
@@ -698,4 +698,11 @@ EOT;
     return $this->storage->countAnalyzedEntities($entity_type_id, $bundle);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    return $this->storage->getAnalyzedEntityIds($entity_type_id, $bundle);
+  }
+
 }

--- a/src/Service/SecurityVectorStorageService.php
+++ b/src/Service/SecurityVectorStorageService.php
@@ -329,7 +329,7 @@ final class SecurityVectorStorageService {
   }
 
   /**
-   * Gets entity IDs that have stored results for a given type and bundle.
+   * Gets entity IDs that have current results for a given type and bundle.
    *
    * @param string $entity_type_id
    *   The entity type ID.
@@ -337,16 +337,39 @@ final class SecurityVectorStorageService {
    *   The bundle.
    *
    * @return array<string|int>
-   *   Array of entity IDs with existing results.
+   *   Array of entity IDs with current results.
    */
   public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+    $data_table = $entity_type->getDataTable() ?: $entity_type->getBaseTable();
+    $id_key = $entity_type->getKey('id');
+    $bundle_key = $entity_type->getKey('bundle');
+
+    if (!$data_table || !$id_key || !$bundle_key || !$this->database->schema()->fieldExists($data_table, 'changed')) {
+      return [];
+    }
+
     $query = $this->database->select('analyze_ai_content_security_audit_results', 'r');
     $query->addField('r', 'entity_id');
+    $query->join($data_table, 'e', "r.entity_id = e.$id_key");
     $query->condition('r.entity_type', $entity_type_id);
-    if ($entity_type_id === 'node') {
-      $query->join('node_field_data', 'n', 'r.entity_id = n.nid AND r.entity_type = :type', [':type' => 'node']);
-      $query->condition('n.type', $bundle);
+    $query->condition("e.$bundle_key", $bundle);
+    $query->condition('r.config_hash', $this->generateConfigHash());
+    $query->where('r.analyzed_timestamp >= e.changed');
+
+    $revision_key = $entity_type->getKey('revision');
+    if ($revision_key && $this->database->schema()->fieldExists($data_table, $revision_key)) {
+      $query->where("r.entity_revision_id = e.$revision_key");
     }
+
+    $langcode_key = $entity_type->getKey('langcode');
+    if ($langcode_key
+      && $this->database->schema()->fieldExists($data_table, 'default_langcode')
+      && $this->database->schema()->fieldExists($data_table, $langcode_key)) {
+      $query->condition('e.default_langcode', 1);
+      $query->where("r.langcode = e.$langcode_key");
+    }
+
     $query->distinct();
     return $query->execute()->fetchCol();
   }

--- a/src/Service/SecurityVectorStorageService.php
+++ b/src/Service/SecurityVectorStorageService.php
@@ -328,4 +328,27 @@ final class SecurityVectorStorageService {
     return (int) $query->execute()->fetchField();
   }
 
+  /**
+   * Gets entity IDs that have stored results for a given type and bundle.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle.
+   *
+   * @return array<string|int>
+   *   Array of entity IDs with existing results.
+   */
+  public function getAnalyzedEntityIds(string $entity_type_id, string $bundle): array {
+    $query = $this->database->select('analyze_ai_content_security_audit_results', 'r');
+    $query->addField('r', 'entity_id');
+    $query->condition('r.entity_type', $entity_type_id);
+    if ($entity_type_id === 'node') {
+      $query->join('node_field_data', 'n', 'r.entity_id = n.nid AND r.entity_type = :type', [':type' => 'node']);
+      $query->condition('n.type', $bundle);
+    }
+    $query->distinct();
+    return $query->execute()->fetchCol();
+  }
+
 }


### PR DESCRIPTION
## Summary

Fixes #14. Implements the new `getAnalyzedEntityIds()` method from `BatchableAnalyzerInterface` (dxpr/analyze#18).

The centralized batch system previously called `hasResults()` on every entity during batch assembly, which triggered full entity rendering via `generateContentHash()`. This caused 504 timeouts on large content sets.

The new method returns entity IDs with existing results via a direct DB query on `analyze_ai_content_security_audit_results`, avoiding entity rendering entirely during assembly.

## Changes

- Add `getAnalyzedEntityIds()` to `AIContentSecurityAuditAnalyzer` plugin, delegating to storage
- Add `getAnalyzedEntityIds()` to `SecurityVectorStorageService` with a `DISTINCT entity_id` query

## Test plan

- [ ] Run batch on a large content set, verify no timeout during form submission
- [ ] Verify already-analyzed entities are correctly excluded from non-force batch runs