### PR TITLE
Add scale labels to security audit results view

### DIFF
--- a/analyze_ai_content_security_audit.module
+++ b/analyze_ai_content_security_audit.module
@@ -47,7 +47,7 @@ function analyze_ai_content_security_audit_views_pre_view(ViewExecutable $view, 
 /**
  * Implements hook_views_color_scale_popover_alter().
  */
-function analyze_ai_content_security_audit_views_color_scale_popover_alter(array &$content, array $context) {
+function analyze_ai_content_security_audit_views_color_scale_popover_alter(array &$content, array $context): void {
   if ($context['view']->storage->get('base_table') !== 'analyze_ai_content_security_audit_results') {
     return;
   }

--- a/analyze_ai_content_security_audit.module
+++ b/analyze_ai_content_security_audit.module
@@ -43,3 +43,26 @@ function analyze_ai_content_security_audit_views_pre_view(ViewExecutable $view, 
     }
   }
 }
+
+/**
+ * Implements hook_views_color_scale_popover_alter().
+ */
+function analyze_ai_content_security_audit_views_color_scale_popover_alter(array &$content, array $context) {
+  if ($context['view']->storage->get('base_table') !== 'analyze_ai_content_security_audit_results') {
+    return;
+  }
+  $content = [
+    '#theme' => 'analyze_gauge',
+    '#caption' => '',
+    '#range_min_label' => t('No Risk'),
+    '#range_mid_label' => t('Medium Risk'),
+    '#range_max_label' => t('High Risk'),
+    '#range_min' => $context['min'],
+    '#value' => $context['position'],
+    '#display_value' => $context['display_value'],
+    '#range_max' => $context['max'],
+    '#attached' => [
+      'library' => ['analyze/gauge-popover'],
+    ],
+  ];
+}

--- a/analyze_ai_content_security_audit.module
+++ b/analyze_ai_content_security_audit.module
@@ -53,7 +53,7 @@ function analyze_ai_content_security_audit_views_color_scale_popover_alter(array
   }
   $content = [
     '#theme' => 'analyze_gauge',
-    '#caption' => '',
+    '#caption' => $context['field_options']['label'] ?? '',
     '#range_min_label' => t('No Risk'),
     '#range_mid_label' => t('Medium Risk'),
     '#range_max_label' => t('High Risk'),

--- a/config/install/views.view.ai_content_security_audit_results.yml
+++ b/config/install/views.view.ai_content_security_audit_results.yml
@@ -215,6 +215,9 @@ display:
           color_scale_auto: 0
           color_scale_min_color: '#B3FFB3'
           color_scale_max_color: '#FFB3B3'
+          color_scale_min_label: 'No Risk'
+          color_scale_mid_label: 'Medium Risk'
+          color_scale_max_label: 'High Risk'
         analyzed_timestamp:
           id: analyzed_timestamp
           table: analyze_ai_content_security_audit_results

--- a/config/install/views.view.ai_content_security_audit_results.yml
+++ b/config/install/views.view.ai_content_security_audit_results.yml
@@ -215,9 +215,6 @@ display:
           color_scale_auto: 0
           color_scale_min_color: '#B3FFB3'
           color_scale_max_color: '#FFB3B3'
-          color_scale_min_label: 'No Risk'
-          color_scale_mid_label: 'Medium Risk'
-          color_scale_max_label: 'High Risk'
         analyzed_timestamp:
           id: analyzed_timestamp
           table: analyze_ai_content_security_audit_results


### PR DESCRIPTION
Fixes #16

Sets `color_scale_min_label` (No Risk), `color_scale_mid_label` (Medium Risk) and `color_scale_max_label` (High Risk) on the color-scaled risk score field of the full-report view, matching the analyzer's summary gauge labels. This view's colors are inverted (green minimum, red maximum); the popover gradient follows the configured colors.

Depends on dxpr/views_color_scales#4, which introduces the label options and the on-hover scale popover that displays them. Existing sites need a config update or view re-import to pick up the labels.