### PR TITLE
Fix drupal-check dependency install in CI

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,5 +23,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Check Drupal compatibility
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         docker compose --profile lint run drupal-check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - .:/src
 
   drupal-check:
-    image: composer:2.7
+    image: composer:2
     profiles: ["lint"]
     working_dir: /
     command: bash -c "/src/scripts/run-drupal-check.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     profiles: ["lint"]
     working_dir: /
     command: bash -c "/src/scripts/run-drupal-check.sh"
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     tty: true
     volumes:
       - .:/src

--- a/scripts/run-drupal-check.sh
+++ b/scripts/run-drupal-check.sh
@@ -3,9 +3,10 @@
 set -vo pipefail
 
 # Authenticate Composer against GitHub to avoid API rate limits, which
-# otherwise make Composer fall back to unauthenticated SSH clones.
+# otherwise make Composer fall back to unauthenticated SSH clones. Using
+# COMPOSER_AUTH keeps the token out of process arguments and auth.json.
 if [ -n "$GITHUB_TOKEN" ]; then
-  composer config -g github-oauth.github.com "$GITHUB_TOKEN"
+  export COMPOSER_AUTH="{\"github-oauth\": {\"github.com\": \"$GITHUB_TOKEN\"}}"
 fi
 
 # Install required libs for Drupal

--- a/scripts/run-drupal-check.sh
+++ b/scripts/run-drupal-check.sh
@@ -2,6 +2,12 @@
 
 set -vo pipefail
 
+# Authenticate Composer against GitHub to avoid API rate limits, which
+# otherwise make Composer fall back to unauthenticated SSH clones.
+if [ -n "$GITHUB_TOKEN" ]; then
+  composer config -g github-oauth.github.com "$GITHUB_TOKEN"
+fi
+
 # Install required libs for Drupal
 GD_ENABLED=$(php -i | grep 'GD Support' | awk '{ print $4 }')
 
@@ -41,7 +47,7 @@ composer require drupal/statistics --no-interaction
 
 # Install the matching Analyze branch until the new batch API is released.
 composer config repositories.dxpr-analyze vcs https://github.com/dxpr/analyze.git --no-interaction
-composer require "dxpr/analyze:1.1.x-dev" drupal/ai drupal/views_color_scales --no-interaction
+composer require "dxpr/analyze:1.1.x-dev" drupal/ai drupal/views_color_scales --no-interaction || exit 1
 
 # Install PHPStan extensions for Drupal 11 and Drush for command analysis
 composer require --dev phpstan/phpstan mglaman/phpstan-drupal phpstan/phpstan-deprecation-rules drush/drush --with-all-dependencies --no-interaction

--- a/src/Service/SecurityVectorStorageService.php
+++ b/src/Service/SecurityVectorStorageService.php
@@ -19,10 +19,10 @@ final class SecurityVectorStorageService {
   use DependencySerializationTrait;
 
   public function __construct(
-    private readonly Connection $database,
-    private readonly ConfigFactoryInterface $configFactory,
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly RendererInterface $renderer,
+    protected readonly Connection $database,
+    protected readonly ConfigFactoryInterface $configFactory,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected readonly RendererInterface $renderer,
   ) {
   }
 


### PR DESCRIPTION
Fixes #18

## Solution

drupal-check had been failing since mid-May because dependency install silently broke, surfacing as unrelated PHPStan class.notFound errors. This PR fixes the whole chain:

- **Composer GitHub auth**: passes `secrets.GITHUB_TOKEN` into the drupal-check container and exposes it to Composer via the `COMPOSER_AUTH` environment variable, so the GitHub API is no longer rate limited and Composer stops falling back to an unauthenticated SSH clone of `dxpr/analyze`. The token never appears in process arguments and no auth.json is written.
- **Composer image**: the drupal-check service tracks `composer:2` because Composer 2.7 validates GitHub tokens against the pre-2025 character set and rejects the runner's newer, longer token; current Composer removed that validation.
- **Fail fast**: the `composer require` for the analyze branch is now fatal, so a dependency failure stops the job at the install step instead of masquerading as module errors.
- **Surfaced code fixes**: with dependencies installing again, PHPStan flagged pre-existing violations that the broken check had hidden: private properties in classes using `DependencySerializationTrait` (the trait cannot restore private properties on unserialization, silently dropping services), now `protected`.